### PR TITLE
fix: tls connection fails when we supply any ssl options to httpc

### DIFF
--- a/src/erlazure.erl
+++ b/src/erlazure.erl
@@ -592,7 +592,7 @@ execute_request(ServiceContext = #service_context{}, ReqContext = #req_context{}
 
         Response = httpc:request(ReqContext#req_context.method,
                                  erlazure_http:create_request(ReqContext, [AuthHeader | Headers1]),
-                                 [{version, "HTTP/1.1"}, {ssl, [{versions, ['tlsv1.2']}]}],
+                                 [{version, "HTTP/1.1"}],
                                  [{sync, true}, {body_format, binary}, {headers_as_is, true}]),
         case Response of
           {ok, {{_, Code, _}, _, Body}}


### PR DESCRIPTION
error when running on current master
```
{error,{failed_connect,[{to_address,{"***.blob.core.windows.net",
                                     443}},
                        {inet,[inet],
                              {tls_alert,{handshake_failure,"TLS client: In state certify at ssl_handshake.erl:2150 generated CLIENT ALERT: Fatal - Handshake Failure\n {bad_cert,hostname_check_failed}"}}}]}}
```

redbug
```
% ssl:opt_cacerts/3 -> {throw,
                           {error,
                               {options,incompatible,
                                   [{verify,verify_peer},
                                    {cacerts,undefined}]}}}
{error,{failed_connect,[{to_address,{"***.blob.core.windows.net",
                                     443}},
                        {inet,[inet],
                              {options,incompatible,
                                       [{verify,verify_peer},{cacerts,undefined}]}}]}}

```